### PR TITLE
bug：[pusher:error] Received invalid JSON 

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -276,7 +276,7 @@ class Server
                 } elseif($channel_type === 'private') {
                     // {"event":"pusher:subscribe","data":{"auth":"b054014693241bcd9c26:10e3b628cb78e8bc4d1f44d47c9294551b446ae6ec10ef113d3d7e84e99763e6","channel_data":"{\"user_id\":100,\"user_info\":{\"name\":\"123\"}}","channel":"presence-channel"}}
                     $client_auth = $data['data']['auth'];
-                    $auth = $connection->appKey.':'.hash_hmac('sha256', $connection->socketID.':'.$channel, $this->appInfo[$connection->appKey]['app_secret'], false);
+                    $auth = $connection->appKey.':'.hash_hmac('sha256', $connection->socketID.':'.$channel.':'.$data['data']['channel_data'], $this->appInfo[$connection->appKey]['app_secret'], false);
                     // {"event":"pusher:error","data":{"code":null,"message":"Received invalid JSON"}}
                     if ($client_auth !== $auth) {
                         return $connection->send($this->error(null, 'Received invalid JSON '.$auth));


### PR DESCRIPTION
## presenceAuth function
```php
 $pusher = new Api(config('plugin.webman.push.app.api'), config('plugin.webman.push.app.app_key'), config('plugin.webman.push.app.app_secret'));
 $channel_name = $request->post('channel_name');
 $session = $request->session();
 // 这里应该通过session和channel_name判断当前用户是否有权限监听channel_name
 $has_authority = true;
 if ($has_authority) {
     $customData = ['name' => 'Tinywan presenceAuth'];
     return response($pusher->presenceAuth($channel_name, $request->post('socket_id'),'1',$customData));
 } else {
     return response('Forbidden', 403);
 }
```
## client
```
[pusher:error] Received invalid JSON 794b06a49101785d970a14997f9c255c:6fb66a01b670c0a9615db997dba99aa4e671f745b1053f6e8fd7aee11f77682c
```
![image](https://user-images.githubusercontent.com/14959876/155331020-43be9491-a9a9-422f-92ae-b082699a3fdc.png)
